### PR TITLE
Avances con el modulo canon minero.

### DIFF
--- a/exp_canon/__manifest__.py
+++ b/exp_canon/__manifest__.py
@@ -28,6 +28,7 @@
         'data/config_default.xml',
         'views/popup_informa_pago.xml',
         'data/cronos_vencimientos.xml',
+        'data/dispara_obligaciones_vencidas.xml',
         'views/popup_select_config.xml',
         'views/popup_config_canon_por_defecto.xml'
     ],

--- a/exp_canon/data/cronos_vencimientos.xml
+++ b/exp_canon/data/cronos_vencimientos.xml
@@ -9,7 +9,7 @@
             <field name="numbercall">-1</field>
             <field name="model_id" ref="model_exp_canon_venc_emitidos"  />
             <field name="state">code</field>
-           <field name="code">model.acciones_planificadas()</field>
+           <field name="code">model.dispara_vencimientos()</field>
            <field eval="False" name="doall"/>
         </record>
 </openerp>

--- a/exp_canon/data/dispara_obligaciones_vencidas.xml
+++ b/exp_canon/data/dispara_obligaciones_vencidas.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<!--    <data noupdate="1">-->
+        <record   id="ir_cron_canon_obligaciones_vencidas" model="ir.cron">
+            <field name="name">Canon Minero - Disparar Obligaciones Vencidas</field>
+            <field name="active" eval="True" />
+            <field name="interval_number">4</field>
+            <field name="interval_type">minutes</field>
+            <field name="numbercall">-1</field>
+            <field name="model_id" ref="model_exp_canon_venc_emitidos"  />
+            <field name="state">code</field>
+           <field name="code">model.busca_obligaciones_vencidas()</field>
+           <field eval="False" name="doall"/>
+        </record>
+</openerp>

--- a/exp_canon/models/models.py
+++ b/exp_canon/models/models.py
@@ -85,6 +85,14 @@ class exp_canon_obligaciones(models.Model):
 
     def notificacion_obligacion_vencida(self):
         print (("DISPARANDO LA NOTIFICACION ..... "))
+        self.env['mail.message'].create({'message_type':"notification",
+                "subtype": self.env.ref("mail.mt_comment").id, # subject type
+                'body': "Message body",
+                'subject': "Message subject",
+                'needaction_partner_ids': [(4, self.user_id.partner_id.id)],   # partner to whom you send notification
+                'model': self._name,
+                'res_id': self.id,
+                })
         return True
 
 class expediente(models.Model):
@@ -99,7 +107,7 @@ class expediente(models.Model):
 
     canon_obligaciones_id = fields.One2many('exp_canon_obligaciones', 'exp_id', string='Obligaciones', required=False)
     cant_vencimientos_no_cumplidos = fields.Integer('Vencimientos No Cumplidos', help='', default=0)
-    config_asociada = fields.Many2one('exp_canon_config', 'Configuracion Canon Asociada', readonly=False, default=default_config_canon, required=True)
+    config_asociada = fields.Many2one('exp_canon_config', 'Configuracion Canon Asociada', readonly=False, default=default_config_canon, required=False)
 
     def informa_pago(self):
         print (("BORRAR"))

--- a/exp_canon/security/ir.model.access.csv
+++ b/exp_canon/security/ir.model.access.csv
@@ -8,3 +8,7 @@ access_exp_canon_leer,exp_canon.exp_cannon_lee,model_exp_canon_obligaciones,exp_
 access_exp_canon_leer_config,exp_canon_lee_config,model_exp_canon_config,exp_canon.exp_canon_lectura,1,0,0,0
 
 access_exp_canon_modifica,exp_canon.exp_cannon_config,model_exp_canon_config,exp_canon.exp_canon_modificacion,1,0,0,0
+
+access_exp_canon_admin_config,exp_canon_admin_config,model_exp_canon_config,exp_canon.exp_canon_configuracion,1,1,1,1
+
+

--- a/exp_canon/views/config_general_canon.xml
+++ b/exp_canon/views/config_general_canon.xml
@@ -22,6 +22,8 @@
         </header>
         <group>
                 <separator string="Configuración de valor General" colspan="4"/>
+                <separator string="Debe validar la configuración actual para utilizarla." 
+                colspan="4" attrs="{'invisible':[('validado','=', True)]}" />
             <!--<spam>En esta pantalla se configura la combinación de trámite y estado, en la cual el sistema debe permitir cambio de trámite en un expediente.<spam/> -->
 
         </group>
@@ -54,6 +56,7 @@
            </group>
            <group>     
                 <field name="validado" readonly="True"/>
+                
                 <button attrs="{'invisible':[('validado','=', True)]}"   name="validar" string="Validar" class="oe_highlight" type="object"
                     confirm="Si confirma la validacion, no podra modificar el valor."/>
           </group>


### PR DESCRIPTION
Separado de cronos: Emite obligaciones una vez al dia, por otro lado dispara obligaciones vencidas cada 4 minutos. Esto es util para desarrollo-prueba y no afecta al producto final.
Faltaba permiso para cambio de configuracion.
Advertencia en pantalla de configuración. Si no está validada, no se puede utilizar.